### PR TITLE
Added a CameraController script.

### DIFF
--- a/Camera Controller/CameraController.cs
+++ b/Camera Controller/CameraController.cs
@@ -1,0 +1,76 @@
+﻿using UnityEngine;
+using System.Collections;
+
+public class CameraController : MonoBehaviour {
+
+    //The object you want to follow.
+    public Transform target;
+
+    //The Distance and Height from the object.
+    public float distance = 20.0f;
+    public float height = 5.0f;
+
+    //If you want to set an offset off the object, chanage this in the inspector.
+    public float lookAtHeight = 0.0f;
+
+    //The Rigidbody of the object you want to follow. Used to determine how far the camera should zoom out when the car moves forward.
+    public Rigidbody targetRigidbody;
+
+    //Time it takes to go to the original rotation (used for delay between current rotation and wanted rotation).
+    public float rotationSnapTime = 0.3f;
+
+    //Time it takes to go back to the original zoom distance dependant of target's Rigidbody velocity.
+    public float distanceSnapTime;
+
+    //Make this around 0.1f for a small zoom out or 0.5f for a large zoom (depending on the speed of your rigidbody).
+    public float distanceMultiplier = 0.0f;
+
+    //For the LookAt function (to look at following object)
+    Vector3 lookAtVector;
+
+    //Used for a reference to the last distance value
+    float usedDistance;
+
+    //These are the variables used to determine the wanted angle of rotation and height.
+    float wantedRotationAngle;
+    float wantedHeight;
+    Vector3 wantedPosition;
+
+    //Comparing these numbers to the wanted rotation angle and height.
+    float currentRotationAngle;
+    float currentHeight;
+
+    //For use in calculating the SmoothDampAngle for the current rotation angle.
+    float yVelocity = 0.0f;
+
+    //For use in calculating the SmoothDampAngle for the used distance.
+    float zVelocity = 0.0f;
+
+    void Start() {
+        //Setting the camera to look at the target.
+        lookAtVector = new Vector3(0, lookAtHeight, 0);
+    }
+
+    void LateUpdate() {
+        wantedHeight = target.position.y + height;
+        currentHeight = transform.position.y;
+
+        wantedRotationAngle = target.eulerAngles.y;
+        currentRotationAngle = transform.eulerAngles.y;
+
+        currentRotationAngle = Mathf.SmoothDampAngle(currentRotationAngle, wantedRotationAngle, ref yVelocity, rotationSnapTime);
+
+        currentHeight = Mathf.Lerp(currentHeight, wantedHeight, Time.deltaTime);
+
+        wantedPosition = target.position;
+        wantedPosition.y = currentHeight;
+
+        usedDistance = Mathf.SmoothDampAngle(usedDistance, distance + (targetRigidbody.velocity.magnitude * distanceMultiplier), ref zVelocity, distanceSnapTime);
+
+        wantedPosition += Quaternion.Euler(0, currentRotationAngle, 0) * new Vector3(0, 0, -usedDistance);
+
+        transform.position = wantedPosition;
+
+        transform.LookAt(target.position + lookAtVector);
+    }
+}

--- a/Camera Controller/CameraController.txt
+++ b/Camera Controller/CameraController.txt
@@ -1,0 +1,23 @@
+This script will force a camera (Main Camera usually, but you can set any camera) to follow a specified GameObject with an assigned height and distance from the object. This may be your player, or an enemy, or a even a car, dream big! This script has an option to zoom the camera in and out depending on the speed in which the target is moving. This script also has an option to delay the camera catching up to the target when it is rotating, showing the sides of the object as it rotates. Both features are fully customisable for how long they last and how extreme they are.
+
+Put a Rigidbody on the target GameObject, if there isn't one already.
+
+Edit any values in the inspector only.
+
+Description of editable values in the inspector:
+	target = The GameObject you want the in-scene camera to follow.
+	distance = Distance from following object.
+	height = The height of the camera.
+	lookAtHeight = The offset off the target.
+	targetRigidbody = The Rigidbody of the object you want to follow. Used to determine how far the camera should zoom out when the car moves forward.
+	rotationSnapTime = The time it takes to snap back to original rotation.
+	distanceSnapTime = The time it takes to snap back to the original zoom distance (depending on speed of targetRigidyBody).
+	distanceMultiplier = Make this around 0.1f for a small zoom out or 0.5f for a large zoom (depending on the speed (velocity) of the target Rigidbody).
+
+Add this code to the PlayerController script, near the bottom of the Update() loop:
+        this.gameObject.GetComponent<Rigidbody>().velocity = transform.forward * moveSpeed / 2;
+								     ^               ^       ^
+					The forward vector of the target	     ^       ^
+										     ^	     ^
+					Name this variable to your speed variable. Change '/ 2' to modify how far the camera will move per unit of speed
+					(I have done '/ 2' as it 'feels' good, change it to what you 'feel' is good for you, you may even times instead).


### PR DESCRIPTION
This script will force a camera (Main Camera usually, but you can set any camera) to follow a specified GameObject with an assigned height and distance from the object. This may be your player, or an enemy, or a even a car, dream big! This script has an option to zoom the camera in and out depending on the speed in which the target is moving. This script also has an option to delay the camera catching up to the target when it is rotating, showing the sides of the object as it rotates. Both features are fully customisable for how long they last and how extreme they are.

This is a slightly modified version of the CameraController script at: http://wiki.unity3d.com/index.php/CarSmoothFollow
